### PR TITLE
fix: patch up parts broken from recent api changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "create-redux-form": "^0.1.2",
     "ethjs": "^0.3.3",
     "history": "^4.7.2",
-    "kleros-api": "^0.3.0",
+    "kleros-api": "^0.4.0",
     "lessdux": "^0.3.0",
     "normalize.css": "^7.0.0",
     "react": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "create-redux-form": "^0.1.2",
     "ethjs": "^0.3.3",
     "history": "^4.7.2",
-    "kleros-api": "^0.4.0",
+    "kleros-api": "^0.4.1",
     "lessdux": "^0.3.0",
     "normalize.css": "^7.0.0",
     "react": "^16.2.0",

--- a/src/components/__snapshots__/storyshots.test.js.snap
+++ b/src/components/__snapshots__/storyshots.test.js.snap
@@ -2337,13 +2337,7 @@ exports[`Storyshots Dispute Card appealable 1`] = `
               </small>
             </h6>
             <h5>
-              <a
-                href="/disputes/undefined"
-                onClick={[Function]}
-              >
-                Unknown Website Owner Claims Services Were Not Delivered
-                
-              </a>
+              Unknown Website Owner Claims Services Were Not Delivered
             </h5>
           </div>
           <div
@@ -2658,13 +2652,7 @@ exports[`Storyshots Dispute Card resolved 1`] = `
               </small>
             </h6>
             <h5>
-              <a
-                href="/disputes/undefined"
-                onClick={[Function]}
-              >
-                Unknown Website Owner Claims Services Were Not Delivered
-                
-              </a>
+              Unknown Website Owner Claims Services Were Not Delivered
             </h5>
           </div>
           <div
@@ -2979,13 +2967,7 @@ exports[`Storyshots Dispute Card waiting 1`] = `
               </small>
             </h6>
             <h5>
-              <a
-                href="/disputes/undefined"
-                onClick={[Function]}
-              >
-                Unknown Website Owner Claims Services Were Not Delivered
-                
-              </a>
+              Unknown Website Owner Claims Services Were Not Delivered
             </h5>
           </div>
           <div

--- a/src/components/balance-pie-chart/index.js
+++ b/src/components/balance-pie-chart/index.js
@@ -10,7 +10,7 @@ const BalancePieChart = ({ type, balance, total, size }) => (
         key: 1,
         color: type === 'activated' ? '#0059ab' : '#47525d'
       },
-      { value: balance ? total - balance : 1, key: 2, color: '#fff' } // if we have no balance set white circle value to 1 to avoid no pie chart
+      { value: balance ? total - balance : 1, key: 2, color: '#fff' } // If total is 0, make the entire pie chart white
     ]}
     startAngle={270}
     lengthAngle={type === 'activated' ? 360 : -360}

--- a/src/components/balance-pie-chart/index.js
+++ b/src/components/balance-pie-chart/index.js
@@ -10,7 +10,7 @@ const BalancePieChart = ({ type, balance, total, size }) => (
         key: 1,
         color: type === 'activated' ? '#0059ab' : '#47525d'
       },
-      { value: total - balance, key: 2, color: '#fff' }
+      { value: balance ? total - balance : 1, key: 2, color: '#fff' } // if we have no balance set white circle value to 1 to avoid no pie chart
     ]}
     startAngle={270}
     lengthAngle={type === 'activated' ? 360 : -360}

--- a/src/components/dispute-card/index.js
+++ b/src/components/dispute-card/index.js
@@ -49,9 +49,11 @@ DisputeCard.propTypes = {
 }
 
 DisputeCard.defaultProps = {
+  // State
+  disputeID: null,
+
   // Modifiers
-  className: '',
-  disputeID: undefined
+  className: ''
 }
 
 export default DisputeCard

--- a/src/components/dispute-card/index.js
+++ b/src/components/dispute-card/index.js
@@ -25,10 +25,13 @@ const DisputeCard = ({
       </small>
     </h6>
     <h5>
-      <Link to={`/disputes/${disputeID}`}>
-        {title}
-        {disputeID ? ` #${disputeID}` : ''}
-      </Link>
+      {disputeID ? (
+        <Link to={`/disputes/${disputeID}`}>
+          {title} {disputeID ? ` #${disputeID}` : ''}
+        </Link>
+      ) : (
+        title
+      )}
     </h5>
   </div>
 )
@@ -37,7 +40,7 @@ DisputeCard.propTypes = {
   // State
   status: PropTypes.number.isRequired,
   subcourt: PropTypes.string.isRequired,
-  disputeID: PropTypes.string.isRequired,
+  disputeID: PropTypes.string,
   date: PropTypes.instanceOf(Date).isRequired,
   title: PropTypes.string.isRequired,
 
@@ -47,7 +50,8 @@ DisputeCard.propTypes = {
 
 DisputeCard.defaultProps = {
   // Modifiers
-  className: ''
+  className: '',
+  disputeID: undefined
 }
 
 export default DisputeCard

--- a/src/sagas/dispute.js
+++ b/src/sagas/dispute.js
@@ -48,11 +48,12 @@ const parseDispute = d => {
     }))
   ]
   events = events.sort((a, b) => (a.data <= b.date || a.data !== null ? -1 : 1))
+
   return {
     ...d,
-    appealCreatedAt: d.appealCreatedAt.map(timestamp => new Date(timestamp)),
-    appealDeadlines: d.appealDeadlines.map(timestamp => new Date(timestamp)),
-    appealRuledAt: d.appealRuledAt.map(timestamp => new Date(timestamp)),
+    appealCreatedAt: d.appealCreatedAt.map(Date),
+    appealDeadlines: d.appealDeadlines.map(Date),
+    appealRuledAt: d.appealRuledAt.map(Date),
     latestAppealForJuror,
     events
   }


### PR DESCRIPTION
- If PNK balance is 0 set a value in pie chart so it still shows empty.
- Only use link in notification card if it relates to a dispute. (e.g. Ready to Activate Tokens has nothing to link to).
- Fix dispute parsing for timestamps.
- return fetchDispute in vote, repartition and execute so that disputes are properly parsed.