### PR TITLE
fix: className typo, arrows wrong directions

### DIFF
--- a/src/components/__snapshots__/storyshots.test.js.snap
+++ b/src/components/__snapshots__/storyshots.test.js.snap
@@ -12550,17 +12550,17 @@ exports[`Storyshots Truncatable Text Box default 1`] = `
           }
         >
           <div
-            className="TruncatableTextBoxTextBox"
+            className="TruncatableTextBox"
           >
             <p>
-              Duis et mauris vestibulum, auctor lacus porttitor, pellentesque arcu. Sed
+              Duis et mauris vestibulum, auctor lacus porttitor, pellentesque arcu. Sed...
             </p>
             <div
-              className="TruncatableTextBoxTextBox-actionDiv"
+              className="TruncatableTextBox-actionDiv"
               onClick={[Function]}
             >
               Show 
-              More ∧
+              More ∨
             </div>
           </div>
           <div
@@ -12857,7 +12857,7 @@ exports[`Storyshots Truncatable Text Box not exceeding max words 1`] = `
           }
         >
           <div
-            className="TruncatableTextBoxTextBox"
+            className="TruncatableTextBox"
           >
             <p>
               Duis et mauris vestibulum, auctor lacus porttitor, pellentesque arcu. Sed scelerisque dolor in orci luctus semper. Mauris turpis magna, congue vitae sollicitudin vel, pretium nec arcu.

--- a/src/components/truncatable-text-box/index.js
+++ b/src/components/truncatable-text-box/index.js
@@ -21,18 +21,18 @@ export default class TruncatableTextBox extends PureComponent {
 
     const words = text.split(' ')
     return (
-      <div className="TruncatableTextBoxTextBox">
+      <div className="TruncatableTextBox">
         <p>
           {truncated && words.length > maxWords
-            ? words.slice(0, maxWords).join(' ')
+            ? words.slice(0, maxWords).join(' ') + '...'
             : text}
         </p>
         {words.length > maxWords && (
           <div
-            className="TruncatableTextBoxTextBox-actionDiv"
+            className="TruncatableTextBox-actionDiv"
             onClick={this.toggleMore}
           >
-            Show {truncated ? 'More ∧' : 'Less ∨'}
+            Show {truncated ? 'More ∨' : 'Less ∧'}
           </div>
         )}
       </div>


### PR DESCRIPTION
- Typo in className
- Arrows pointing wrong direction
- Add '...' if text is truncated