### PR TITLE
fix: initialize kleros before accounts

### DIFF
--- a/src/bootstrap/initializer.js
+++ b/src/bootstrap/initializer.js
@@ -28,8 +28,8 @@ class Initializer extends PureComponent {
   async componentDidMount() {
     const { fetchAccounts } = this.props
 
+    await initializeKleros() // Kleros must be initialized before fetchAccounts as accounts triggers notifications sagas.
     fetchAccounts()
-    await initializeKleros()
 
     this.setState({ initialized: true })
   }

--- a/src/bootstrap/initializer.js
+++ b/src/bootstrap/initializer.js
@@ -28,7 +28,7 @@ class Initializer extends PureComponent {
   async componentDidMount() {
     const { fetchAccounts } = this.props
 
-    await initializeKleros() // Kleros must be initialized before fetchAccounts as accounts triggers notifications sagas.
+    await initializeKleros() // Kleros must be initialized before fetchAccounts as accounts trigger notifications sagas
     fetchAccounts()
 
     this.setState({ initialized: true })

--- a/src/bootstrap/initializer.js
+++ b/src/bootstrap/initializer.js
@@ -28,7 +28,7 @@ class Initializer extends PureComponent {
   async componentDidMount() {
     const { fetchAccounts } = this.props
 
-    await initializeKleros() // Kleros must be initialized before fetchAccounts as accounts trigger notifications sagas
+    await initializeKleros() // Kleros must be initialized before fetchAccounts as accounts trigger notification sagas
     fetchAccounts()
 
     this.setState({ initialized: true })


### PR DESCRIPTION
- There was a race condition where if accounts are fetched before Kleros is initialized Notifications saga will start and `kleros` will be undefined