### PR TITLE
Fix/slow loading disputes

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "create-redux-form": "^0.1.2",
     "ethjs": "^0.3.3",
     "history": "^4.7.2",
-    "kleros-api": "^0.14.2",
+    "kleros-api": "^0.15.0",
     "lessdux": "^0.7.3",
     "normalize.css": "^7.0.0",
     "react": "^16.2.0",

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -65,6 +65,7 @@ class Table extends PureComponent {
         </div>
         <ReactTable
           // Number of Rows
+          minRows={filteredData.length < 7 ? filteredData.length || 3 : 7}
           pageSizeOptions={[7, 14, 28, 56, 112]}
           defaultPageSize={7}
           // Indicators

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -65,7 +65,6 @@ class Table extends PureComponent {
         </div>
         <ReactTable
           // Number of Rows
-          minRows={filteredData.length || 3}
           pageSizeOptions={[7, 14, 28, 56, 112]}
           defaultPageSize={7}
           // Indicators

--- a/src/constants/date.js
+++ b/src/constants/date.js
@@ -1,16 +1,16 @@
 export const MONTHS_ENUM = [
-  'January',
-  'February',
+  'Jan',
+  'Feb',
   'March',
   'April',
   'May',
   'June',
   'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December'
+  'Aug',
+  'Sept',
+  'Oct',
+  'Nov',
+  'Dec'
 ]
 
 export const ORDINAL_INDICATOR_ENUM = [


### PR DESCRIPTION
- Use month abbreviations so the deadline isn't too long to fit in Disputes table
- More than 7 disputes was making the disputes table minRows larger than pagination amount. If more than 7 disputes use 7 as min.