### PR TITLE
fix: add message when there is no web3 - issue #129

### DIFF
--- a/src/bootstrap/initializer.js
+++ b/src/bootstrap/initializer.js
@@ -57,6 +57,10 @@ class Initializer extends PureComponent {
           {children}
         </ChainView>
       )
+    } else if (window.web3) {
+      return (
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Loading...</span>
+      )
     } else return <RequiresMetaMask needsUnlock={false} />
   }
 }

--- a/src/bootstrap/initializer.js
+++ b/src/bootstrap/initializer.js
@@ -57,10 +57,7 @@ class Initializer extends PureComponent {
           {children}
         </ChainView>
       )
-    } else
-      return (
-        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Loading...</span>
-      )
+    } else return <RequiresMetaMask needsUnlock={false} />
   }
 }
 


### PR DESCRIPTION
Added a message when there is no Metamask installed in your browser. Requested by issue #129 