### PR TITLE
fix: add message when there is no web3

### DIFF
--- a/src/bootstrap/initializer.js
+++ b/src/bootstrap/initializer.js
@@ -58,10 +58,11 @@ class Initializer extends PureComponent {
           {children}
         </ChainView>
       )
-    }
-    return (
-      <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Loading...</span>
-    )
+    } else if (window.web3) {
+      return (
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Loading...</span>
+      )
+    } else return <RequiresMetaMask needsUnlock={false} />
   }
 }
 


### PR DESCRIPTION
Added a message when there is no Metamask installed in your browser. Requested by issue #129