### PR TITLE
feat: disputes table loads deadlines in new call

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "create-redux-form": "^0.1.2",
     "ethjs": "^0.3.3",
     "history": "^4.7.2",
-    "kleros-api": "^0.15.0",
+    "kleros-api": "^0.16.0",
     "lessdux": "^0.7.3",
     "normalize.css": "^7.0.0",
     "react": "^16.2.0",

--- a/src/actions/dispute.js
+++ b/src/actions/dispute.js
@@ -3,7 +3,10 @@ import { createActions } from 'lessdux'
 /* Actions */
 
 // Disputes
-export const disputes = createActions('DISPUTES')
+export const disputes = {
+  ...createActions('DISPUTES', { withUpdate: true }),
+  FETCH_DEADLINES: 'FETCH_DISPUTE_DEADLINES'
+}
 
 // Dispute
 export const dispute = {
@@ -17,6 +20,10 @@ export const dispute = {
 
 // Disputes
 export const fetchDisputes = () => ({ type: disputes.FETCH })
+export const fetchDisputeDeadlines = _disputes => ({
+  type: disputes.FETCH_DEADLINES,
+  payload: { _disputes }
+})
 
 // Dispute
 export const fetchDispute = disputeID => ({

--- a/src/containers/disputes/components/disputes-table/index.js
+++ b/src/containers/disputes/components/disputes-table/index.js
@@ -8,6 +8,11 @@ import CaseNameCell from '../case-name-cell'
 
 const columns = [
   {
+    show: false,
+    accessor: 'disputeId',
+    id: 'disputeId'
+  },
+  {
     Header: 'Case Name',
     minWidth: 220,
     Cell: CaseNameCell
@@ -22,8 +27,8 @@ const columns = [
     maxWidth: 140,
     accessor: 'deadline',
     Cell: cell =>
-      cell.value === null
-        ? 'None'
+      cell.value == null
+        ? 'Loading...'
         : dateToString(cell.value, { withYear: false })
   },
   {
@@ -41,7 +46,11 @@ const DisputesTable = ({ disputes }) => (
     data={disputes.data}
     defaultSorted={[
       {
-        id: 'deadline',
+        id: 'status',
+        desc: false
+      },
+      {
+        id: 'disputeId',
         desc: true
       }
     ]}

--- a/src/containers/disputes/index.js
+++ b/src/containers/disputes/index.js
@@ -16,7 +16,12 @@ class Disputes extends PureComponent {
     disputes: disputeSelectors.disputesShape.isRequired,
 
     // Action Dispatchers
-    fetchDisputes: PropTypes.func.isRequired
+    fetchDisputes: PropTypes.func.isRequired,
+    fetchDisputeDeadlines: PropTypes.func.isRequired
+  }
+
+  state = {
+    loadedDeadlines: false
   }
 
   componentDidMount() {
@@ -24,9 +29,17 @@ class Disputes extends PureComponent {
     fetchDisputes()
   }
 
+  componentDidUpdate() {
+    const { fetchDisputeDeadlines, disputes } = this.props
+    const { loadedDeadlines } = this.state
+    if (!loadedDeadlines && disputes && disputes.data) {
+      fetchDisputeDeadlines(disputes.data)
+      this.setState({ loadedDeadlines: true })
+    }
+  }
+
   render() {
     const { disputes } = this.props
-
     const table = <DisputesTable disputes={disputes} />
     return (
       <div className="Disputes">
@@ -48,6 +61,7 @@ export default connect(
     disputes: state.dispute.disputes
   }),
   {
-    fetchDisputes: disputeActions.fetchDisputes
+    fetchDisputes: disputeActions.fetchDisputes,
+    fetchDisputeDeadlines: disputeActions.fetchDisputeDeadlines
   }
 )(Disputes)

--- a/src/reducers/dispute.js
+++ b/src/reducers/dispute.js
@@ -18,11 +18,13 @@ const {
       rulingChoices: PropTypes.number.isRequired,
       state: PropTypes.number.isRequired,
       status: PropTypes.number.isRequired,
+      deadline: PropTypes.string,
       voteCounters: PropTypes.arrayOf(
         PropTypes.arrayOf(PropTypes.number.isRequired).isRequired
       ).isRequired
     }).isRequired
-  )
+  ),
+  { withUpdate: true }
 )
 const {
   shape: disputeShape,


### PR DESCRIPTION
- Load deadlines separately from all disputes
- Sorts table by `status` (open disputes at the top) and then by `disputeID` since we no longer have deadline at the onset.

Note: Biggest speed bottleneck now is loading the metaEvidence